### PR TITLE
FIX Include composer package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "heyday/silverstripe-backstop",
 	"description": "Helps log non-200 errors",
+	"type": "silverstripe-module",
 	"authors": [
 		{
 			"name": "Cam Spiers",


### PR DESCRIPTION
Without the composer package type being set to `silverstripe-module` the package is installed in the `vendor` dir. This prevents the `_config/config.yml` file from being included by SilverStripe. Which prevents the package from working as the configuration is required.
